### PR TITLE
Broker abort signal

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -1978,6 +1978,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/jest", "npm:26.0.23"],
             ["@types/node", "npm:15.12.2"],
             ["jest", "virtual:a58b2b25f01677cfb3a9cd4e4d274526187eb012964f52805295463a2665a7c1a12fb18addd3ceb966ef8873216da7d1c3d5f3b97dbf38238181ed7d83b87a9f#npm:27.0.5"],
+            ["node-abort-controller", "npm:2.0.0"],
             ["rimraf", "npm:3.0.2"],
             ["semantic-release", "npm:17.4.4"],
             ["semantic-release-monorepo", "virtual:ef53acb3e556e8586e85c1524cb077098189b6b2054df55a6469ac7b17eed141e3b3b6643ec3fd30e875186b47092db3ae7758e00c1259fc7e8530c9d83d4575#npm:7.0.5"],

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@johngw/async": "^4.0.0",
     "@johngw/async-iterator": "^2.2.0",
+    "node-abort-controller": "^2.0.0",
     "ts-toolbelt": "^9.6.0",
     "tslib": "^2.3.0"
   }

--- a/packages/message-bus/src/Broker.ts
+++ b/packages/message-bus/src/Broker.ts
@@ -13,6 +13,7 @@ import type {
   InvokerInterceptorArgs,
   InvokerRegistrationArgs,
 } from './types/invokables'
+import { Subscription } from './types/MessageBus'
 
 export default class Broker<
   Events extends EventsT = EventsT,
@@ -33,7 +34,7 @@ export default class Broker<
     return this.abortController.signal
   }
 
-  onAbort(fn: () => any) {
+  readonly onAbort = (fn: () => any) => {
     this.abortController.signal.addEventListener('abort', fn)
   }
 
@@ -51,21 +52,21 @@ export default class Broker<
   interceptEvent<EventName extends keyof Events>(
     eventName: EventName,
     ...args: EventInterceptorArgs<Events[EventName]>
-  ): () => void {
+  ): Subscription {
     return this.messageBus.interceptEvent(this as any, eventName, args)
   }
 
   on<EventName extends keyof Events>(
     eventName: EventName,
     ...args: SubscriberArgs<Events[EventName]>
-  ): () => void {
+  ): Subscription {
     return this.messageBus.on(this, eventName, args)
   }
 
   once<EventName extends keyof Events>(
     eventName: EventName,
     ...args: SubscriberArgs<Events[EventName]>
-  ): () => void {
+  ): Subscription {
     return this.messageBus.once(this, eventName, args)
   }
 
@@ -90,7 +91,7 @@ export default class Broker<
       EventGens[EventName]['args'],
       EventGens[EventName]['yield']
     >
-  ): () => void {
+  ): Subscription {
     return this.messageBus.generator(this, eventName, args)
   }
 
@@ -130,7 +131,7 @@ export default class Broker<
       Invokables[InvokableName]['args'],
       Invokables[InvokableName]['return']
     >
-  ): () => void {
+  ): Subscription {
     return this.messageBus.register(this, invokableName, args)
   }
 
@@ -144,7 +145,7 @@ export default class Broker<
   interceptInvoker<InvokableName extends keyof Invokables>(
     invokableName: InvokableName,
     ...args: InvokerInterceptorArgs<Invokables[InvokableName]['args']>
-  ): () => void {
+  ): Subscription {
     return this.messageBus.interceptInvoker(this, invokableName, args)
   }
 }

--- a/packages/message-bus/src/MessageBus.test.ts
+++ b/packages/message-bus/src/MessageBus.test.ts
@@ -1,7 +1,7 @@
 import Broker from './Broker'
 import MessageBus from './MessageBus'
 import { CancelEvent } from './symbols'
-import { timeout } from '@johngw/async'
+import { AbortError, timeout } from '@johngw/async'
 import MessageBusError from './MessageBusError'
 
 describe('events', () => {
@@ -188,7 +188,13 @@ describe('invokables', () => {
     bar = jest.fn((x: string) => x + '1')
     broker.register('foo', foo)
     broker.register('bar', bar)
-    broker.register('never', () => new Promise(() => {}))
+    const { onAbort } = broker.register(
+      'never',
+      () =>
+        new Promise((_, reject) => {
+          onAbort(() => reject(new AbortError()))
+        })
+    )
   })
 
   test('returning values', async () => {

--- a/packages/message-bus/src/MessageBusError.ts
+++ b/packages/message-bus/src/MessageBusError.ts
@@ -1,0 +1,8 @@
+export default class MessageBusError extends Error {
+  constructor(
+    public readonly brokerId: string,
+    public readonly originalError: Error
+  ) {
+    super(`${brokerId}: ${originalError.message}`)
+  }
+}

--- a/packages/message-bus/src/index.ts
+++ b/packages/message-bus/src/index.ts
@@ -1,3 +1,4 @@
+export { AbortError } from '@johngw/async'
 export { default as Broker } from './Broker'
 export { CancelEvent } from './symbols'
 export { default as MessageBus } from './MessageBus'

--- a/packages/message-bus/src/types/MessageBus.ts
+++ b/packages/message-bus/src/types/MessageBus.ts
@@ -1,5 +1,11 @@
+import type { AbortSignal } from 'node-abort-controller'
 import type Broker from '../Broker'
 import type MessageBus from '../MessageBus'
+
+export interface Subscription {
+  cancel(): void
+  onAbort(fn: () => any): any
+}
 
 export type MessageBusEvents<MB extends MessageBus> = MB extends MessageBus<
   infer Events,

--- a/packages/message-bus/src/types/MessageBus.ts
+++ b/packages/message-bus/src/types/MessageBus.ts
@@ -1,4 +1,3 @@
-import type { AbortSignal } from 'node-abort-controller'
 import type Broker from '../Broker'
 import type MessageBus from '../MessageBus'
 

--- a/packages/plugin-manager/src/PluginManager.ts
+++ b/packages/plugin-manager/src/PluginManager.ts
@@ -302,7 +302,7 @@ export default class PluginManager<
 
   #createContext({ name }: Plugin, signal: AbortSignal) {
     return {
-      broker: this.#messageBus.broker(name) as MessageBusBroker<MB>,
+      broker: this.#messageBus.broker(name, signal) as MessageBusBroker<MB>,
       signal,
       ...((this.#createExtraContext && this.#createExtraContext(name)) || {}),
     } as Context<MB> & ExtraContext & ExtraRunContext

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,7 @@ __metadata:
     "@types/jest": 26.0.23
     "@types/node": 15.12.2
     jest: 27.0.5
+    node-abort-controller: ^2.0.0
     rimraf: 3.0.2
     semantic-release: 17.4.4
     semantic-release-monorepo: 7.0.5


### PR DESCRIPTION
All subscribing functions (on, generator, invoker, interceptEvent,
interceptInvoker) now return a subscription object containing an
onabort subscribing function.

BREAKING CHANGE: The return signature for subscribing functions has
changed.